### PR TITLE
Drop inflecto from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,2 @@
 source "https://rubygems.org"
 gemspec
-
-group :test do
-  gem 'inflecto'
-end


### PR DESCRIPTION
Both gemspec and Gemfile include the inflecto gem (and Bundler rightfully whines about it).
